### PR TITLE
metadata: specify Edwin as the preferred text font

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,6 +22,7 @@
         "stemThickness": 0.11,
         "subBracketThickness": 0.11,
         "textEnclosureThickness": 0.11,
+        "textFontFamily": ["Edwin", "serif"],
         "thickBarlineThickness": 0.55,
         "thinBarlineThickness": 0.18,
         "tieEndpointThickness": 0.07,


### PR DESCRIPTION
Advertise the fact that Edwin is meant to complement Leland by adding it to the `engravingDefaults.textFontFamily` key. I could add Century Schoolbook and clones to the list of names, but I don't find it necessary yet.